### PR TITLE
Fix copy-paste error in System32Location in Paths.cs

### DIFF
--- a/DWS/lib/Paths.cs
+++ b/DWS/lib/Paths.cs
@@ -11,7 +11,7 @@ namespace DWS_Lite.lib
                 SysDir + @"Windows\Sysnative\cmd.exe" : SysDir + @"Windows\System32\cmd.exe";
         public static string System32Location = 
             (File.Exists(SysDir + @"Windows\Sysnative\cmd.exe")) ? 
-                SysDir + @"Windows\System32\" : SysDir + @"Windows\System32\";
+                SysDir + @"Windows\Sysnative\" : SysDir + @"Windows\System32\";
 
 
     }


### PR DESCRIPTION
I presume this is a copy-paste error, since both sides of ?: are the same.