### PR TITLE
Fix Hostname

### DIFF
--- a/DWS/MainDwsForm.cs
+++ b/DWS/MainDwsForm.cs
@@ -857,7 +857,7 @@ namespace DWS_Lite
                     "secure.adnxs.com",
                     "secure.flashtalking.com",
                     "services.wes.df.telemetry.microsoft.com",
-                    "settings.data.microsof.com",
+                    "settings.data.microsoft.com",
                     "settings-sandbox.data.microsoft.com",
                     "settings-win.data.microsoft.com",
                     "sls.update.microsoft.com.akadns.net",


### PR DESCRIPTION
settings.data.microsof.com > settings.data.microsof**t**.com

settings.data.microsof.com does not exist.

`→ sudo ping settings.data.microsof.com
ping: unknown host settings.data.microsof.com
`
vs
`→ sudo ping settings.data.microsoft.com
PING db5.settings.data.microsoft.com.akadns.net (191.232.139.253) 56(84) bytes of data.
`